### PR TITLE
Minor API changes & bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ add `gem 'sprockets-vue'` to Gemfile, and run bundle, currently works with sproc
 ```vue
 //= require components/card
 <script lang="coffee">
-vm = {
+module.exports = {
   data: ->
     search: ''
     members: []

--- a/README.md
+++ b/README.md
@@ -7,9 +7,14 @@ A [Sprockets](https://github.com/rails/sprockets) transformer that converts .vue
 
 
 # heads up!
-version 0.0.6 has incompatible change, due to bugs in previous version.
 
-now you should assign `vm` variable to make it works!
+version 0.1.0 has incompatible changes, attempting to make the syntax
+work more similarly to Webpack/vue-loader.
+
+Specifically:
+
+- You should assign `module.exports` variable to make it work! (not vm)
+- Now supports normal javascript (as well as coffeescript)
 
 # feature
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ add `gem 'sprockets-vue'` to Gemfile, and run bundle, currently works with sproc
 # example
 * index.vue
 ```vue
-//= require compents/card
+//= require components/card
 <script lang="coffee">
 vm = {
   data: ->
     search: ''
     members: []
   components:
-    card: VCompents['compents/card']
+    card: VComponents['components/card']
   methods:
     clear: ->
       this.search = ''
@@ -66,7 +66,7 @@ vm = {
 new Vue(
   el: '#search',
   components: {
-    'index': VCompents.index
+    'index': VComponents.index
   }
 )
 ```

--- a/lib/sprockets/vue/script.rb
+++ b/lib/sprockets/vue/script.rb
@@ -27,12 +27,12 @@ module Sprockets::Vue
             result = SCRIPT_COMPILES[script[:lang]].call(script[:content], input)
             map = result['sourceMap']
 
-            output << "'object' != typeof VCompents && (VCompents = {});
-              #{result['js']}; VCompents['#{name}'] = vm;"
+            output << "'object' != typeof VComponents && (VComponents = {});
+              #{result['js']}; VComponents['#{name}'] = vm;"
           end
 
           if template
-            output << "VCompents['#{name.sub(/\.tpl$/, "")}'].template = '#{j template[:content]}';"
+            output << "VComponents['#{name.sub(/\.tpl$/, "")}'].template = '#{j template[:content]}';"
           end
 
           { data: "#{warp(output.join)}", map: map }

--- a/lib/sprockets/vue/script.rb
+++ b/lib/sprockets/vue/script.rb
@@ -30,7 +30,7 @@ module Sprockets::Vue
             map = result['sourceMap']
 
             output << "'object' != typeof VComponents && (this.VComponents = {});
-              var module = { exports: nil };
+              var module = { exports: null };
               #{result['js']}; VComponents['#{name}'] = module.exports;"
           end
 

--- a/lib/sprockets/vue/script.rb
+++ b/lib/sprockets/vue/script.rb
@@ -13,7 +13,8 @@ module Sprockets::Vue
         },
         'es6' => ->(s, input){
           Babel::Transpiler.transform(data, {}) #TODO
-        }
+        },
+        nil => ->(s,input){ { 'js' => s } }
       }
       def call(input)
         data = input[:data]
@@ -25,6 +26,7 @@ module Sprockets::Vue
           map = nil
           if script
             result = SCRIPT_COMPILES[script[:lang]].call(script[:content], input)
+            
             map = result['sourceMap']
 
             output << "'object' != typeof VComponents && (VComponents = {});

--- a/lib/sprockets/vue/script.rb
+++ b/lib/sprockets/vue/script.rb
@@ -29,8 +29,9 @@ module Sprockets::Vue
             
             map = result['sourceMap']
 
-            output << "'object' != typeof VComponents && (VComponents = {});
-              #{result['js']}; VComponents['#{name}'] = vm;"
+            output << "'object' != typeof VComponents && (this.VComponents = {});
+              var module = { exports: nil };
+              #{result['js']}; VComponents['#{name}'] = module.exports;"
           end
 
           if template

--- a/lib/sprockets/vue/version.rb
+++ b/lib/sprockets/vue/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module Vue
-    VERSION = '0.0.6'
+    VERSION = '0.0.7'
   end
 end

--- a/lib/sprockets/vue/version.rb
+++ b/lib/sprockets/vue/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module Vue
-    VERSION = '0.0.7'
+    VERSION = '0.0.7-1'
   end
 end

--- a/lib/sprockets/vue/version.rb
+++ b/lib/sprockets/vue/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module Vue
-    VERSION = '0.0.7-1'
+    VERSION = '0.1.0'
   end
 end

--- a/test/fixtures/index.vue
+++ b/test/fixtures/index.vue
@@ -5,7 +5,7 @@ vm = {
     search: 'test'
     members: []
   components:
-    card: VCompents['compents/card']
+    card: VComponents['components/card']
   methods:
     clear: ->
       this.search = ''

--- a/test/test_vue.rb
+++ b/test/test_vue.rb
@@ -26,8 +26,8 @@ class TestVue < MiniTest::Test
     asset = @env['index.js'].to_s
     context = ExecJS.compile(asset)
 
-    assert_equal context.eval("VCompents.index.data().search"), 'test'
-    components = context.eval("VCompents", bare: true)
+    assert_equal context.eval("VComponents.index.data().search"), 'test'
+    components = context.eval("VComponents", bare: true)
     assert_equal components.keys, ["components/card", "index"]
     assert components['index']['template'].match(/clear-icon glyphicon glyphicon-remove/)
     assert components['components/card']['template'].match(/@click='expand=!expand'/)


### PR DESCRIPTION
I've changed the API to be more rememberable (to me, anyway, comments welcome) by using VComponents (instead of VCompents, which I found myself typo-ing all the time), `module.exports` (instead of `vm`).  Since this is a lightweight version of vue-loader for webpack, I wanted the usage to be as similar as possible to it.