### PR TITLE
Enable use of sprockets directives by running the script content through preprocessors

### DIFF
--- a/test/fixtures/index_with_sprockets_require.vue
+++ b/test/fixtures/index_with_sprockets_require.vue
@@ -1,0 +1,19 @@
+<script lang="coffee">
+#= require javascripts/js-plugin
+module.exports = {
+
+  methods:
+    callPlugin: ->
+      SuperFancyJavascriptPlugin.hello
+      
+}
+</script>
+
+<template>
+  <div class="container">
+    <p> {{ callPlugin }} </p>
+  </div>
+</template>
+
+<style lang="scss">
+</style>

--- a/test/fixtures/javascripts/js-plugin.js
+++ b/test/fixtures/javascripts/js-plugin.js
@@ -1,0 +1,3 @@
+this.SuperFancyJavascriptPlugin = {
+  hello: "Hello World"
+};

--- a/test/test_vue.rb
+++ b/test/test_vue.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'sprockets'
-require 'sprockets/vue'
+require 'rails-vue-loader'
 require 'execjs'
 require "coffee-script"
 require 'sass'
@@ -37,5 +37,12 @@ class TestVue < MiniTest::Test
     asset = @env['index.css'].to_s
     assert asset.match(/.search .icon-input/)
     assert asset.match(/.avatar/)
+  end
+
+  def test_sprockets_preprocessor
+    asset = @env['index_with_sprockets_require.js'].to_s
+    context = ExecJS.compile(asset)
+
+    assert_equal 'Hello World', context.eval("SuperFancyJavascriptPlugin.hello")
   end
 end


### PR DESCRIPTION
As stated in the README and the tests, it's already possible to use sprockets directives like `require` outside of the three tags (`template`, `script`, `style`).

This seems to only work with `.vue` files. 
I wanted to `require` an external JS-plugin in order to add a Vue integration for it.
Therefore, it's now possible to add sprockets directives inside the `script` tag.

However, it's currently not possible to use both at the same time.

The existing tests still passed - I've added an additional test for the new functionality.